### PR TITLE
Removed brew usage from the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
           make deps
-          brew install conan
+          pip install conan
           conan config install https://github.com/conan-io/conanclientcert.git
       - run: cmake -DCMAKE_BUILD_TYPE=Debug . && make
       - run: GTEST_COLOR=1 ASAN_OPTIONS=detect_leaks=0 ctest -VV

--- a/deps/ledger-zxlib/.github/workflows/main.yml
+++ b/deps/ledger-zxlib/.github/workflows/main.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install deps
         run: |
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-          brew install conan
+          pip install conan
           conan config install https://github.com/conan-io/conanclientcert.git
       - run: cmake -DCMAKE_BUILD_TYPE=Debug . && make


### PR DESCRIPTION
Python package manager is used to install conan instead of brew.